### PR TITLE
Support uppercase hex characters, 1–2 digit hex numbers, and `Adr`

### DIFF
--- a/lib/syntaxes/marie.tmGrammar.json
+++ b/lib/syntaxes/marie.tmGrammar.json
@@ -10,6 +10,9 @@
       "include": "#directives"
     },
     {
+      "include": "#keywords"
+    },
+    {
       "include": "#instructions"
     },
     {
@@ -39,6 +42,11 @@
       "comment": "Directive",
       "match": "(?i)\\b(org|oct|dec|hex)\\b",
       "name": "entity.name.function.directive.marie"
+    },
+    "keywords": {
+      "comment": "Keyword",
+      "match": "(?i)\\badr\\b",
+      "name": "keyword.other.marie"
     },
     "instructions": {
       "comment": "Instruction",

--- a/lib/syntaxes/marie.tmGrammar.json
+++ b/lib/syntaxes/marie.tmGrammar.json
@@ -76,7 +76,7 @@
     },
     "hex-numbers": {
       "comment": "Hex numbers",
-      "match": "\\b([0-9a-f][0-9a-f][0-9a-f]+)\\b",
+      "match": "\\b([0-9a-fA-F]+)\\b",
       "name": "constant.numeric.hex.marie"
     }
   }


### PR DESCRIPTION
This PR implements better syntax highlighting for the following:

```
HEX ABC / uppercase hex characters
HEX 0A  / 2 digit hex number
HEX A   / 1 digit hex number

Zero, HEX 0
AddressOfZero, Adr Zero / Adr keyword
```

I’m not sure if `keyword.other.marie` is the correct scope for `Adr` and I’m happy to change it.